### PR TITLE
Tighten lower bound on `base`

### DIFF
--- a/safecopy-store.cabal
+++ b/safecopy-store.cabal
@@ -29,7 +29,7 @@ Library
   Hs-Source-Dirs:      src/
 
   -- Packages needed in order to build this package.
-  Build-depends:       base >=4.5 && <5,
+  Build-depends:       base >=4.8 && <5,
                        array < 0.6,
                        bytestring < 0.11,
                        containers >= 0.3 && < 0.6,


### PR DESCRIPTION
Otherwise cabal runs into compile failures w/ pre-AMP base:

```
Configuring component lib from safecopy-store-0.9.3...
Preprocessing library safecopy-store-0.9.3...
[1 of 6] Compiling Data.SafeCopy.Store.Encode ( src/Data/SafeCopy/Store/Encode.hs, /tmp/matrix-worker/1492786630/dist-newstyle/build/x86_64-linux/ghc-7.8.4/safecopy-store-0.9.3/build/Data/SafeCopy/Store/Encode.o )

src/Data/SafeCopy/Store/Encode.hs:22:10:
    Not in scope: type constructor or class ‘Applicative’

```